### PR TITLE
Fixing typos: Chapter 2 to 5

### DIFF
--- a/content/ch02-starting-to-code.html
+++ b/content/ch02-starting-to-code.html
@@ -150,7 +150,7 @@ function draw() {
 
 <p>Ahora puedes abrir este directorio en tu editor de c&#xF3;digo y empezar a hacer un nuevo bosquejo. Cuando quieras verlo en el navegador, abre el archivo <em>index.html </em>ubicado en tu nuevo directorio <em>Proyecto-2</em>.</p>
 
-<p>Siempre es una buena idea grabar frecuentemente tus bosquejos. Mientras vas probando cosas nuevas, graba tu bosquejo con diferentes nombres, (Archivo→Guardar como), para que as&#xED; siempre puedas volver a versiones anteriores.  Esto es especialmente &#xFA;til si algo&nbsp;<a contenteditable="false" data-primary="new project" data-startref="np2" data-type="indexterm">&nbsp;</a>falla.</p>
+<p>Siempre es una buena idea grabar frecuentemente tus bosquejos. Mientras vas probando cosas nuevas, graba tu bosquejo con diferentes nombres, (Archivo→Guardar como), para que as&#xED; siempre puedas volver a versiones anteriores.  Esto es especialmente &#xFA;til si algo&nbsp;<a contenteditable="false" data-primary="new project" data-startref="np2" data-type="indexterm"></a>falla.</p>
 
 <div data-type="note">
 <p>Un error com&#xFA;n es estar editando un proyecto pero estar viendo otro en el navegador, haciendo que no puedas ver los cambios que has realizado. Si te das cuenta que tu programa se ve igual a pesar de haber hecho cambios en tu c&#xF3;digo, revisa que est&#xE1;s viendo el archivo <em>index.html</em> correcto.</p>
@@ -166,6 +166,6 @@ function draw() {
 
 <p>La <em>Referencia de p5.js</em> explica cada elemento de c&#xF3;digo con una descripci&#xF3;n y ejemplos. Los programas de la <em>Referencia</em> son mucho m&#xE1;s cortos (usualmente cuatro o cinco l&#xED;neas) y m&#xE1;s f&#xE1;ciles de seguir que los ejemplos de la <a href="https://p5js.org/es/learn/">p&#xE1;gina Aprender</a>. Ten en cuenta que estos ejemplos por simplicidad usualmente omiten <code>setup()</code> y <code>draw()</code>, pero estas l&#xED;neas de c&#xF3;digo que ves deber&#xE1;n ubicarse dentro de uno de estos bloques para poder ser ejecutadas. Recomendamos mantener la p&#xE1;gina de <em>Referencia</em> abierta mientras est&#xE9;s leyendo este libro y mientras est&#xE9;s programando. Puede ser navegada por tema o usando la barra de b&#xFA;squeda en la parte superior de la p&#xE1;gina.</p>
 
-<p>La <em>Referencia</em> fue escrita pensando en el principiante; esperamos que sea clara y facil de entender. Estamos muy agradecidos de las personas que han encontrado errores y los han se&#xF1;alado. Si crees que puedes mejorar una entrada en la referencia o que has encontrado alg&#xFA;n error, por favor haznos saber esto haciendo click en el enlace en la parte inferior de cada<a contenteditable="false" data-primary="coding basics" data-startref="cb2" data-type="indexterm">&nbsp;</a>p&#xE1;gina de referencia.</p>
+<p>La <em>Referencia</em> fue escrita pensando en el principiante; esperamos que sea clara y f&#xE1;cil de entender. Estamos muy agradecidos de las personas que han encontrado errores y los han se&#xF1;alado. Si crees que puedes mejorar una entrada en la referencia o que has encontrado alg&#xFA;n error, por favor haznos saber esto haciendo click en el enlace en la parte inferior de cada<a contenteditable="false" data-primary="coding basics" data-startref="cb2" data-type="indexterm">&nbsp;</a>p&#xE1;gina de referencia.</p>
 </section>
 </section>

--- a/content/ch03-draw.html
+++ b/content/ch03-draw.html
@@ -51,7 +51,7 @@ function draw() {
 <section data-type="sect1">
 <h1>Figuras b&#xE1;sicas</h1>
 
-<p>p5.js incluye un grupo de funciones para dibujar figuras b&#xE1;sicas (ver <a data-type="xref" href="#Fig_03_01">Figura 3-1</a>). Figuras simples<a contenteditable="false" data-primary="shapes" data-secondary="drawing basic" data-type="indexterm" id="s3db">&nbsp;</a><a contenteditable="false" data-primary="basic shapes" data-type="indexterm" id="bs3">&nbsp;</a><a contenteditable="false" data-primary="drawing" data-secondary="lines" data-type="indexterm" id="d3lines">&nbsp;</a><a contenteditable="false" data-primary="drawing" data-secondary="shapes" data-tertiary="basic" data-type="indexterm" id="d3sb">&nbsp;</a>como l&#xED;neas pueden ser combinadas para crear figuras m&#xE1;s complicadas como una hoja o una cara.</p>
+<p>p5.js incluye un grupo de funciones para dibujar figuras b&#xE1;sicas (ver <a data-type="xref" href="#Fig_03_01">Figura 3-1</a>). Figuras simples<a contenteditable="false" data-primary="shapes" data-secondary="drawing basic" data-type="indexterm" id="s3db">&nbsp;</a><a contenteditable="false" data-primary="basic shapes" data-type="indexterm" id="bs3"></a><a contenteditable="false" data-primary="drawing" data-secondary="lines" data-type="indexterm" id="d3lines"></a><a contenteditable="false" data-primary="drawing" data-secondary="shapes" data-tertiary="basic" data-type="indexterm" id="d3sb"></a>como l&#xED;neas pueden ser combinadas para crear figuras m&#xE1;s complicadas como una hoja o una cara.</p>
 
 <p>Para dibujar una sola&nbsp;<a contenteditable="false" data-primary="lines" data-secondary="drawing" data-type="indexterm" id="ld3">&nbsp;</a>l&#xED;nea, necesitamos cuatro par&#xE1;metros: dos para el punto inicial y dos para el final.</p>
 

--- a/content/ch04-variables.html
+++ b/content/ch04-variables.html
@@ -211,7 +211,7 @@ var x = (4 + 4) * 5; // Se le asigna el valor 40 a x</pre>
 
 <p>En clases de matem&#xE1;ticas se ense&#xF1;a un acr&#xF3;nimo para este orden: PEMDAS, <a contenteditable="false" data-primary="PEMDAS acronym" data-type="indexterm">&nbsp;</a>que significa Par&#xE9;ntesis, Exponentes, Multiplicaci&#xF3;n, Divisi&#xF3;n, Adici&#xF3;n, Substracci&#xF3;n, donde los par&#xE9;ntesis tienen la mayor prioridad y la substracci&#xF3;n la menor.<a contenteditable="false" data-primary="order of operations" data-type="indexterm">&nbsp;</a><a contenteditable="false" data-primary="arithmetic operations" data-secondary="order of" data-type="indexterm">&nbsp;</a>El orden completo de operaciones se encuentra en el <a data-type="xref" href="#order_of_operations">Apéndice B</a>.</p>
 
-<p>Algunos c&#xE1;lculos son usados tan frecuentemente en programaci&#xF3;n que se han elaborado atajos, lo que es &#xFA;til para ahorrar tiempo al escribir. Por ejemplo, puedes sumar a o restar  una variable con un solo operador:</p>
+<p>Algunos c&#xE1;lculos son usados tan frecuentemente en programaci&#xF3;n que se han elaborado atajos, lo que es &#xFA;til para ahorrar tiempo al escribir. Por ejemplo, puedes sumar o restar a una variable con un solo operador:</p>
 
 <pre data-code-language="p5js" data-type="programlisting">
 x += 10; // Es equivalente a x = x + 10
@@ -537,7 +537,7 @@ function draw() {
 <figcaption/>
 </figure>
 
-<p>Las <a contenteditable="false" data-primary="robot programs (examples)" data-secondary="modifying code with variables" data-type="indexterm" id="rp4mcwv">&nbsp;</a>variables introducidas en este programa hacen que el c&#xF3;digo se vea m&#xE1;s dif&#xED;cil que el de la Robot 1 (ver <a data-type="xref" href="#robot1">Robot 1: dibuja</a>), pero ahora es mucho m&#xE1;s simple hacer modificaciones, porque los n&#xFA;meros que dependen uno de otro est&#xE1;n en una misma ubicaci&#xF3;n. Por ejemplo, el dibujo del cuello est&#xE1; basado en la variable <code>neckHeight</code>. El grupo de variables al principio del c&#xF3;digo controla los aspectos del robot que queremos cambiar: ubicaci&#xF3;n, altura del cuerpo y altura del cuello. Puedes observar algunas de las posibles variaciones posibles en la figura; de izquierda a derecha, aqu&#xed;; est&#xE1;n los valores correspondientes:</p>
+<p>Las <a contenteditable="false" data-primary="robot programs (examples)" data-secondary="modifying code with variables" data-type="indexterm" id="rp4mcwv">&nbsp;</a>variables introducidas en este programa hacen que el c&#xF3;digo se vea m&#xE1;s dif&#xED;cil que el de la Robot 1 (ver <a data-type="xref" href="#robot1">Robot 1: dibuja</a>), pero ahora es mucho m&#xE1;s simple hacer modificaciones, porque los n&#xFA;meros que dependen uno de otro est&#xE1;n en una misma ubicaci&#xF3;n. Por ejemplo, el dibujo del cuello est&#xE1; basado en la variable <code>neckHeight</code>. El grupo de variables al principio del c&#xF3;digo controla los aspectos del robot que queremos cambiar: ubicaci&#xF3;n, altura del cuerpo y altura del cuello. Puedes observar algunas de las posibles variaciones en la figura; de izquierda a derecha, aqu&#xed; est&#xE1;n los valores correspondientes:</p>
 
 <table class="smallerText">
 	<tbody>
@@ -574,7 +574,7 @@ neckHeight = 140
 	</tbody>
 </table>
 
-<p>Cuando modifiques tu propio c&#xF3;digo para usar variables en vez de n&#xFA;meros, planea cuidadosamente los cambios y despu&#xE9;s realiza las modificaciones en incrementos graduales. Por ejemplo, cuando este programa fue escrito, cada variable fue creada a una a la vez para minimizar la complejidad de la transici&#xF3;n. Solamente despu&#xE9;s de que una variable fuera creada y el c&#xF3;digo era ejecutado para asegurar que funcionara correctamente, se a&#xF1;ad&#xED;a una nueva variable:</p>
+<p>Cuando modifiques tu propio c&#xF3;digo para usar variables en vez de n&#xFA;meros, planea cuidadosamente los cambios y despu&#xE9;s realiza las modificaciones en incrementos graduales. Por ejemplo, cuando este programa fue escrito, cada variable fue creada una a la vez para minimizar la complejidad de la transici&#xF3;n. Solamente despu&#xE9;s de que una variable fuera creada y el c&#xF3;digo fuera ejecutado para asegurar que funcionara correctamente, se a&#xF1;ad&#xED;a una nueva variable:</p>
 
 <pre data-code-language="p5js" data-type="programlisting">
 var x = 60;            // Coordenada x

--- a/content/ch05-response.html
+++ b/content/ch05-response.html
@@ -31,7 +31,7 @@ Estoy dibujando
 3
 ...</pre>
 
-<p>En el programa de ejemplo anterior, las funciones <code>print()</code> escriben el texto "Estoy dibujando" seguido del contador actual de cuadros, tarea efectuada por la variable especial <code>frameCount</code> (1, 2, 3, …). El texto aparece en la consola de tu navegador.</p>
+<p>En el programa del ejemplo anterior, las funciones <code>print()</code> escriben el texto "Estoy dibujando" seguido del contador actual de cuadros, tarea efectuada por la variable especial <code>frameCount</code> (1, 2, 3, …). El texto aparece en la consola de tu navegador.</p>
 </section>
 
 <section data-type="sect2">


### PR DESCRIPTION
Hey @montoyamoraga , 

I'm opening this PR with fixes to a few minor typos I found in chapters 2 to 5. Typos are related to:

- Missing accents

- Extra spaces between words

- Confusing wording 

Hope this is helpful. 

Best,
