### PR TITLE
Quick edits to two examples

### DIFF
--- a/content/ch05-response.html
+++ b/content/ch05-response.html
@@ -251,7 +251,7 @@ function draw() {
   var objetivoX = mouseX;
   x += (objetivoX - x) * suavizado;
   var objetivoY = mouseY;
-  y += (objetivoX - y) * suavizado;
+  y += (objetivoY - y) * suavizado;
   var peso = dist(x, y, px, py);
   strokeWeight(peso);
   line(x, y, px, py);

--- a/content/ch06-translate.html
+++ b/content/ch06-translate.html
@@ -337,7 +337,7 @@ function draw() {
   if (mouseIsPressed) {
     scale(1.0);
   } else {
-    scale(0.6);  // 60% de tamaño si el ratón está presionado
+    scale(0.6);  // 60% de tamaño si el ratón no está presionado
   }
 
   // Cuerpo


### PR DESCRIPTION
- ch05-response.html example: quick fix here to make the code do what the examples says. As it is currently,  `y += (objetivoX - y) * suavizado` when the line is drawn in the canvas, it will only downwards towards the left hand corner. Noticed that the issue there was that `objetivoY` was not being used. 

- content/ch06-translate.html: just doing a quick fix here to the comment to make it clearer and follow what the example says in the description (emphasis mine). 
`Cuando el rat&#xF3;n no est&#xE1; presionado, el tama&#xF1;o es de un 60% y cuando s&#xED; est&#xE1; presionado, es de un 100% en relaci&#xF3;n a las coordenadas originales`